### PR TITLE
JENKINS-51697 Include timezone on next execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,4 @@
           </dependency>
         </dependencies>
       </dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.12.5</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/src/main/java/hudson/plugins/nextexecutions/NextBuilds.java
+++ b/src/main/java/hudson/plugins/nextexecutions/NextBuilds.java
@@ -3,22 +3,20 @@ package hudson.plugins.nextexecutions;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.plugins.nextexecutions.Messages;
 import hudson.util.FormValidation;
-
 import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
-import java.util.Date;
+import java.util.TimeZone;
 
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
 import org.jenkinsci.Symbol;
-import org.joda.time.DateTime;
-import org.joda.time.Period;
-import org.joda.time.PeriodType;
-import org.joda.time.format.PeriodFormatter;
-import org.joda.time.format.PeriodFormatterBuilder;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import hudson.Util;
@@ -36,7 +34,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class NextBuilds implements Comparable, Describable<NextBuilds>{
 	private ParameterizedJobMixIn.ParameterizedJob project;
 	private String name;
-	private String dateString;
 	private Calendar date;
 	
 	public NextBuilds(ParameterizedJobMixIn.ParameterizedJob project, Calendar date) {
@@ -44,41 +41,40 @@ public class NextBuilds implements Comparable, Describable<NextBuilds>{
 		this.name = Util.escape(project.getDisplayName());
 		this.date = date;
 	}
-	
-	private String formatDate(Date d) {
+
+	private String formatDate(ZonedDateTime d) {
 		String dateFormat = this.getDescriptor().getDateFormat();
 		if(dateFormat == null){
 			dateFormat = this.getDescriptor().getDefault();
 		}
-		SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
-		return sdf.format(d.getTime());
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateFormat);
+		return formatter.format(d);
 	}
 	
 	@Exported
 	public String getDate() {
-		return formatDate(date.getTime());
+		return formatDate(ZonedDateTime.ofInstant(Instant.ofEpochMilli(date.getTimeInMillis()), date.getTimeZone().toZoneId()));
 	}
 	
 	public String getTimeToGo() {
-		DateTime now = new DateTime();
-		
-		PeriodType periodType = PeriodType.dayTime();
-		periodType = periodType.withMillisRemoved();
-		Period timeToGo = new Period(now, new DateTime(date.getTimeInMillis()),
-				periodType);  
-
-		PeriodFormatter pf = new PeriodFormatterBuilder().
-			appendDays().
-			appendSuffix("d").
-			appendSeparatorIfFieldsBefore(" ").
-			appendHours().
-			appendSuffix("h").
-			appendSeparatorIfFieldsBefore(" ").
-			appendMinutes().
-			appendSuffix("m").
-			toFormatter();
-		
-		return Messages.timeToGo(pf.print(timeToGo));
+		ZoneId zone = date.getTimeZone().toZoneId();
+		ZonedDateTime now = ZonedDateTime.now(zone);
+		ZonedDateTime zonedDate = ZonedDateTime.ofInstant(Instant.ofEpochMilli(date.getTimeInMillis()), zone);
+		Duration duration = Duration.between(now, zonedDate);
+		long days = duration.toDays();
+		long hours = duration.toHours() % 24;
+		long minutes = duration.toMinutes() % 60;
+		StringBuilder sb = new StringBuilder();
+		if (days > 0) {
+			sb.append(days).append("d ");
+		}
+		if (hours > 0) {
+			sb.append(hours).append("h ");
+		}
+		if (minutes > 0) {
+			sb.append(minutes).append("m");
+		}
+		return Messages.timeToGo(sb.toString());
 	}
 	
 	@Exported
@@ -172,7 +168,7 @@ public class NextBuilds implements Comparable, Describable<NextBuilds>{
 		}
 
 		public String getDefault() {
-			return "dd/MM/yyyy HH:mm";
+			return "dd/MM/yyyy HH:mm z";
 		}
 		
 		public boolean getFilterByViewDefault() {

--- a/src/main/java/hudson/plugins/nextexecutions/NextExecutionsWidget.java
+++ b/src/main/java/hudson/plugins/nextexecutions/NextExecutionsWidget.java
@@ -81,7 +81,6 @@ public class NextExecutionsWidget extends Widget {
 			l = j.getItems(ParameterizedJobMixIn.ParameterizedJob.class);
 		}
 		
-		
 		for (ParameterizedJobMixIn.ParameterizedJob project: l) {
 			NextBuilds nb = NextExecutionsUtils.getNextBuild(project, triggerClass);
 			if(nb != null)

--- a/src/main/java/hudson/plugins/nextexecutions/utils/NextExecutionsUtils.java
+++ b/src/main/java/hudson/plugins/nextexecutions/utils/NextExecutionsUtils.java
@@ -4,6 +4,7 @@ import hudson.model.AbstractProject;
 import java.lang.reflect.Field;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Vector;
 
@@ -15,6 +16,8 @@ import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.TimeZone;
+
 import jenkins.model.ParameterizedJobMixIn;
 
 public class NextExecutionsUtils {
@@ -32,6 +35,7 @@ public class NextExecutionsUtils {
 
     public static NextBuilds getNextBuild(ParameterizedJobMixIn.ParameterizedJob project, Class<? extends Trigger> triggerClass) {
         Calendar cal = null;
+        TimeZone timezone = null;
         // Only AbstractProject has isDisabled method
         if ((project instanceof AbstractProject && !((AbstractProject) project).isDisabled())
                 || !(project instanceof AbstractProject)) {
@@ -52,8 +56,9 @@ public class NextExecutionsUtils {
                         List<CronTab> crons = (Vector<CronTab>) crontablistTabsField.get(cronTabList);
 
                         for (CronTab cronTab : crons) {
-                            Date d = new Date();
-                            cal = (cal == null || cal.compareTo(cronTab.ceil(d.getTime())) > 0) ? cronTab.ceil(d.getTime()) : cal;
+                            timezone = cronTab.getTimeZone() != null ? cronTab.getTimeZone() : TimeZone.getDefault();
+                            Calendar now = new GregorianCalendar(timezone);
+                            cal = (cal == null || cal.compareTo(cronTab.ceil(now)) > 0) ? cronTab.ceil(now) : cal;
                         }
                     } catch (NoSuchFieldException e) {
                         e.printStackTrace();


### PR DESCRIPTION
- Include timezone on next execution. Timezone that is displayed (if user select so) is the one configured on the cron using the TZ=<timezone> 
- Also get rid of Joda Time (use only Java8 time)

![timezone](https://user-images.githubusercontent.com/825750/233908324-77ec5619-78d6-4a28-93c9-2ab0b3b0b79f.PNG)
![job1](https://user-images.githubusercontent.com/825750/233907682-8f7d28bf-9cfa-4ceb-bb71-3c1117d86c93.PNG)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
