### PR TITLE
Downstream example of pluggable widgets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   </scm>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.375.4</jenkins.version>
+    <jenkins.version>2.404-rc33641.c79f96b_b_6874</jenkins.version>
     <gitHubRepo>jenkinsci/next-executions-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/main/java/hudson/plugins/nextexecutions/NextExecutionsWidget.java
+++ b/src/main/java/hudson/plugins/nextexecutions/NextExecutionsWidget.java
@@ -1,5 +1,6 @@
 package hudson.plugins.nextexecutions;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Api;
 import hudson.model.Queue;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Vector;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
+import jenkins.widgets.WidgetFactory;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -36,14 +38,24 @@ import org.kohsuke.stapler.export.ExportedBean;
  *
  */
 @ExportedBean
-@Extension
 @SuppressWarnings("rawtypes")
 public class NextExecutionsWidget extends Widget {
+    private final String ownerUrl;
 
-    protected Class<? extends Trigger> triggerClass;
+    private Class<? extends Trigger> triggerClass;
 
-    public NextExecutionsWidget() {
-        triggerClass = TimerTrigger.class;
+    public NextExecutionsWidget(String ownerUrl) {
+        this(ownerUrl, TimerTrigger.class);
+    }
+
+    public NextExecutionsWidget(String ownerUrl, Class<? extends Trigger> triggerClass) {
+        this.ownerUrl = ownerUrl;
+        this.triggerClass = triggerClass;
+    }
+
+    @Override
+    public String getOwnerUrl() {
+        return ownerUrl;
     }
 
     public Api getApi() {
@@ -149,5 +161,24 @@ public class NextExecutionsWidget extends Widget {
             return false;
         }
         return d.getShowParameterizedWidget();
+    }
+
+    @Extension
+    public static final class FactoryImpl extends WidgetFactory<View, NextExecutionsWidget> {
+        @Override
+        public Class<View> type() {
+            return View.class;
+        }
+
+        @Override
+        public Class<NextExecutionsWidget> widgetType() {
+            return NextExecutionsWidget.class;
+        }
+
+        @NonNull
+        @Override
+        public Collection<NextExecutionsWidget> createFor(@NonNull View target) {
+            return List.of(new NextExecutionsWidget(target.getUrl()));
+        }
     }
 }

--- a/src/main/java/hudson/plugins/nextexecutions/ParameterizedNextExecutionsWidget.java
+++ b/src/main/java/hudson/plugins/nextexecutions/ParameterizedNextExecutionsWidget.java
@@ -1,15 +1,19 @@
 package hudson.plugins.nextexecutions;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.model.View;
 import hudson.plugins.nextexecutions.NextBuilds.DescriptorImpl;
+import java.util.Collection;
+import java.util.List;
 import jenkins.model.Jenkins;
+import jenkins.widgets.WidgetFactory;
 import org.jenkinsci.plugins.parameterizedscheduler.ParameterizedTimerTrigger;
 
-@Extension(optional = true)
 public class ParameterizedNextExecutionsWidget extends NextExecutionsWidget {
 
-    public ParameterizedNextExecutionsWidget() {
-        triggerClass = ParameterizedTimerTrigger.class;
+    public ParameterizedNextExecutionsWidget(String ownerUrl) {
+        super(ownerUrl, ParameterizedTimerTrigger.class);
     }
 
     @Override
@@ -31,5 +35,25 @@ public class ParameterizedNextExecutionsWidget extends NextExecutionsWidget {
     @Override
     public String getWidgetId() {
         return super.getWidgetId() + "-parameterized";
+    }
+
+    @Extension(optional = true)
+    public static final class FactoryImpl extends WidgetFactory<View, ParameterizedNextExecutionsWidget> {
+
+        @Override
+        public Class<View> type() {
+            return View.class;
+        }
+
+        @Override
+        public Class<ParameterizedNextExecutionsWidget> widgetType() {
+            return ParameterizedNextExecutionsWidget.class;
+        }
+
+        @NonNull
+        @Override
+        public Collection<ParameterizedNextExecutionsWidget> createFor(@NonNull View target) {
+            return List.of(new ParameterizedNextExecutionsWidget(target.getUrl()));
+        }
     }
 }

--- a/src/main/java/hudson/plugins/nextexecutions/PossibleNextExecutionsWidget.java
+++ b/src/main/java/hudson/plugins/nextexecutions/PossibleNextExecutionsWidget.java
@@ -1,15 +1,19 @@
 package hudson.plugins.nextexecutions;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.model.View;
 import hudson.plugins.nextexecutions.NextBuilds.DescriptorImpl;
 import hudson.triggers.SCMTrigger;
+import java.util.Collection;
+import java.util.List;
 import jenkins.model.Jenkins;
+import jenkins.widgets.WidgetFactory;
 
-@Extension
 public class PossibleNextExecutionsWidget extends NextExecutionsWidget {
 
-    public PossibleNextExecutionsWidget() {
-        triggerClass = SCMTrigger.class;
+    public PossibleNextExecutionsWidget(String ownerUrl) {
+        super(ownerUrl, SCMTrigger.class);
     }
 
     @Override
@@ -31,5 +35,25 @@ public class PossibleNextExecutionsWidget extends NextExecutionsWidget {
     @Override
     public String getWidgetId() {
         return super.getWidgetId() + "-possible";
+    }
+
+    @Extension
+    public static final class FactoryImpl extends WidgetFactory<View, PossibleNextExecutionsWidget> {
+
+        @Override
+        public Class<View> type() {
+            return View.class;
+        }
+
+        @Override
+        public Class<PossibleNextExecutionsWidget> widgetType() {
+            return PossibleNextExecutionsWidget.class;
+        }
+
+        @NonNull
+        @Override
+        public Collection<PossibleNextExecutionsWidget> createFor(@NonNull View target) {
+            return List.of(new PossibleNextExecutionsWidget(target.getUrl()));
+        }
     }
 }


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins/pull/7932

Converted widgets in view, NextExecutionsComputerWidget could be converted to a Widget with a WidgetFactory applicable to Computer.

![Capture d’écran 2023-05-05 à 17 54 36](https://user-images.githubusercontent.com/171459/236507345-d39a7d8c-467f-4808-a47b-136e9d8076c4.png)


<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
