### PR TITLE
Only create parameterized next execution widget if plugin is installed

### DIFF
--- a/src/main/java/hudson/plugins/nextexecutions/ParameterizedNextExecutionsWidget.java
+++ b/src/main/java/hudson/plugins/nextexecutions/ParameterizedNextExecutionsWidget.java
@@ -55,7 +55,10 @@ public class ParameterizedNextExecutionsWidget extends NextExecutionsWidget {
         @NonNull
         @Override
         public Collection<ParameterizedNextExecutionsWidget> createFor(@NonNull View target) {
-            return List.of(new ParameterizedNextExecutionsWidget(target.getUrl()));
+            if (Jenkins.get().getPlugin("parameterized-scheduler") != null) {
+                return List.of(new ParameterizedNextExecutionsWidget(target.getUrl()));
+            }
+            return List.of();
         }
     }
 }

--- a/src/main/resources/hudson/plugins/nextexecutions/ParametrizedNextExecutionsWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/ParametrizedNextExecutionsWidget/index.jelly
@@ -1,5 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:if test="${it.showWidget()}">
 <j:if test="${!it.builds.isEmpty()}">
 <l:pane width="2" title="${it.widgetName}" id="${it.widgetId}">
   <j:forEach var="w" items="${it.builds}">
@@ -9,5 +10,6 @@
     </tr>
   </j:forEach>
 </l:pane>
+</j:if>
 </j:if>
 </j:jelly>


### PR DESCRIPTION
Fix https://github.com/jenkinsci/next-executions-plugin/issues/42

### Testing done

mvn hpi run
remove parameterized-scheduler and test that widget appears

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
