### PR TITLE
Remove Jenkins core version when building JDK 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,9 @@
 /*
- See the documentation for more options:
- https://github.com/jenkins-infra/pipeline-library/
-*/
-buildPlugin(
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
-  configurations: [
-    [platform: 'linux', jdk: 17],
-    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
-    [platform: 'windows', jdk: 11],
+ * See the documentation for more options:
+ * https://github.com/jenkins-infra/pipeline-library/
+ */
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'windows', jdk: 11],
+  [ platform: 'linux', jdk: 17],
+  [ platform: 'linux', jdk: 21],
 ])


### PR DESCRIPTION
Remove Jenkins core version when building JDK 21

### Testing done

CI

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
