### PR TITLE
Use same style as other Jenkins widgets

### DIFF
--- a/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsComputerWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsComputerWidget/index.jelly
@@ -4,8 +4,8 @@
 <l:pane width="2" title="${it.widgetName}" id="${it.widgetId}">
   <j:forEach var="w" items="${it.builds}">
     <tr>
-      <td><a tooltip="${w.name}" href="${w.url}">${w.shortName}</a></td>
-      <td>${w.date}</td>
+      <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.shortName}</a></td>
+      <td class="pane">${w.date}</td>
     </tr>
   </j:forEach>
 </l:pane>

--- a/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsWidget/index.jelly
@@ -24,8 +24,8 @@
   <l:pane width="2" title="${it.widgetName}" id="${it.widgetId}">
     <j:forEach var="w" items="${it.builds}">
       <tr>
-        <td><a tooltip="${w.name}" href="${w.url}">${w.name}</a></td>
-        <td tooltip="${w.timeToGo}">${w.date}</td>
+        <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.name}</a></td>
+        <td class="pane" tooltip="${w.timeToGo}">${w.date}</td>
       </tr>
     </j:forEach>
   </l:pane>

--- a/src/main/resources/hudson/plugins/nextexecutions/ParametrizedNextExecutionsWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/ParametrizedNextExecutionsWidget/index.jelly
@@ -5,8 +5,8 @@
 <l:pane width="2" title="${it.widgetName}" id="${it.widgetId}">
   <j:forEach var="w" items="${it.builds}">
     <tr>
-      <td><a tooltip="${w.name}" href="${w.url}">${w.shortName}</a></td>
-      <td tooltip="${w.timeToGo}">${w.date}</td>
+      <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.shortName}</a></td>
+      <td class="pane" tooltip="${w.timeToGo}">${w.date}</td>
     </tr>
   </j:forEach>
 </l:pane>


### PR DESCRIPTION
Fix https://github.com/jenkinsci/next-executions-plugin/issues/59

Use pane class for table cells

![widgets](https://github.com/jenkinsci/next-executions-plugin/assets/825750/e84512bb-a38d-4302-894b-c0c0477d0673)


### Testing done

```
mvn hpi:run -Dport=8081 -Dhost=0.0.0.0
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
