### PR TITLE
Remove displayMode setting (fixes #78)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,6 @@ nextBuilds:
   filterByView: false
   showPossibleWidget: false
   showParameterizedWidget: false
-  displayMode: 1
 ----
 
 

--- a/src/main/java/hudson/plugins/nextexecutions/NextBuilds.java
+++ b/src/main/java/hudson/plugins/nextexecutions/NextBuilds.java
@@ -115,7 +115,6 @@ public class NextBuilds implements Comparable, Describable<NextBuilds> {
         private Boolean filterByView;
         private Boolean showPossibleWidget;
         private Boolean showParameterizedWidget;
-        private Integer displayMode;
 
         public DescriptorImpl() {
             load();
@@ -161,17 +160,6 @@ public class NextBuilds implements Comparable, Describable<NextBuilds> {
             this.showParameterizedWidget = showParameterizedWidget;
         }
 
-        public Integer getDisplayMode() {
-            if (displayMode == null) {
-                return 1;
-            }
-            return displayMode;
-        }
-
-        public void setDisplayMode(Integer displayMode) {
-            this.displayMode = displayMode;
-        }
-
         public String getDefault() {
             return "dd/MM/yyyy HH:mm z";
         }
@@ -186,7 +174,6 @@ public class NextBuilds implements Comparable, Describable<NextBuilds> {
             filterByView = json.getBoolean("filterByView");
             showPossibleWidget = json.getBoolean("showPossibleWidget");
             showParameterizedWidget = json.getBoolean("showParameterizedWidget");
-            displayMode = json.getInt("displayMode");
             save();
             return true;
         }

--- a/src/main/java/hudson/plugins/nextexecutions/NextExecutionsWidget.java
+++ b/src/main/java/hudson/plugins/nextexecutions/NextExecutionsWidget.java
@@ -141,17 +141,6 @@ public class NextExecutionsWidget extends Widget {
         return true;
     }
 
-    // Default displayMode will be 1
-    public int getDisplayMode() {
-        Jenkins j = Jenkins.getInstanceOrNull();
-        DescriptorImpl d = j != null ? (DescriptorImpl) (j.getDescriptorOrDie(NextBuilds.class)) : null;
-
-        if (d == null) {
-            return 1;
-        }
-        return d.getDisplayMode();
-    }
-
     public boolean getShowParameterizedWidget() {
         Jenkins j = Jenkins.getInstanceOrNull();
         DescriptorImpl d = j != null ? (DescriptorImpl) (j.getDescriptorOrDie(NextBuilds.class)) : null;

--- a/src/main/resources/hudson/plugins/nextexecutions/NextBuilds/global.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/NextBuilds/global.jelly
@@ -13,10 +13,5 @@
     <f:entry title="${%Show Parameterized Next Executions Widget}" field="showParameterizedWidget">
       <f:checkbox />
     </f:entry>
-    <f:entry title="${%Widget Display mode}" help="/plugin/next-executions/displayMode.html">
-       <f:radio name="displayMode" value="1" title="${%Truncate}" checked="${descriptor.displayMode == 1}"/>
-       <f:radio name="displayMode" value="2" title="${%Fixed Width}" checked="${descriptor.displayMode == 2}"/>
-       <f:radio name="displayMode" value="3" title="${%Jenkins}" checked="${descriptor.displayMode == 3}"/>
-    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsWidget/index.jelly
@@ -1,26 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <j:if test="${it.showWidget()}">
-  <style>
-  <j:if test="${it.displayMode==1}">
-  	#${it.widgetId} table {
-  		table-layout: fixed;
-  	}
-    #${it.widgetId} td {
-        text-overflow: ellipsis;
-        overflow: hidden;
-    }
-  </j:if>
-  <j:if test="${it.displayMode==2}">
-  	#${it.widgetId} table {
-  		table-layout: fixed;
-  	}
-  	#${it.widgetId} td {
-  		word-wrap: break-word;
-  		white-space: normal;
-  	}
-  </j:if>
-  </style>
   <l:pane width="2" title="${it.widgetName}" id="${it.widgetId}">
     <j:forEach var="w" items="${it.builds}">
       <tr>

--- a/src/main/webapp/displayMode.html
+++ b/src/main/webapp/displayMode.html
@@ -1,8 +1,0 @@
-<div>
-Display Modes:
-  <ul>
-    <li>Truncate Mode: if the job name is too long, truncate it.</li>
-    <li>Fixed Width Mode: if the job name is too long, it wraps to next line.</li>
-    <li>Jenkins Mode: if the job name is too long, extend the widget's width.</li>
-  </ul>
-</div>


### PR DESCRIPTION
Complety remove the "display mode" setting. It has been broken since some time
(maybe as long as the table-to-div layout change).

### Testing done

Started Jenkins with `mvn hpi:run` to verify the setting is gone. Jenkins shows
the "Old Data" warning and the remaining data can be removed with that feature.
Widget still looks the same to me.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
