### PR TITLE
Display message when not next execution is found to avoid empty widget

### DIFF
--- a/src/main/java/hudson/plugins/nextexecutions/NextExecutionsComputerWidget.java
+++ b/src/main/java/hudson/plugins/nextexecutions/NextExecutionsComputerWidget.java
@@ -39,6 +39,10 @@ public class NextExecutionsComputerWidget extends Widget {
         return Messages.NextExecComputer_WidgetName();
     }
 
+    public String getWidgetEmptyMessage() {
+        return Messages.NextExec_EmptyWidgetMessage();
+    }
+
     public String getWidgetId() {
         return "next-exec-computer";
     }

--- a/src/main/java/hudson/plugins/nextexecutions/NextExecutionsWidget.java
+++ b/src/main/java/hudson/plugins/nextexecutions/NextExecutionsWidget.java
@@ -133,6 +133,10 @@ public class NextExecutionsWidget extends Widget {
         return Messages.NextExec_WidgetName();
     }
 
+    public String getWidgetEmptyMessage() {
+        return Messages.NextExec_EmptyWidgetMessage();
+    }
+
     public String getWidgetId() {
         return "next-exec";
     }

--- a/src/main/resources/hudson/plugins/nextexecutions/Messages.properties
+++ b/src/main/resources/hudson/plugins/nextexecutions/Messages.properties
@@ -1,6 +1,7 @@
 Format.Error=The date format pattern is not valid.
 timeToGo=(in {0})
 NextExec.WidgetName=Next Executions
+NextExec.EmptyWidgetMessage=No next executions found.
 NextExecComputer.WidgetName=Next Executions tied to this agent
 PossibleNextExec.WidgetName=Possible Next Executions
 ParameterizedExec.WidgetName=Parameterized Next Executions

--- a/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsComputerWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsComputerWidget/index.jelly
@@ -2,12 +2,16 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 <l:pane width="2" title="${it.widgetName}" id="${it.widgetId}">
-  <j:forEach var="w" items="${it.builds}">
-    <tr>
-      <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.shortName}</a></td>
-      <td class="pane">${w.date}</td>
-    </tr>
-  </j:forEach>
+  <j:if test="${!it.builds.isEmpty()}">
+    <j:forEach var="w" items="${it.builds}">
+      <tr>
+        <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.shortName}</a></td>
+        <td class="pane">${w.date}</td>
+      </tr>
+    </j:forEach>
+  </j:if>
+  <j:if test="${it.builds.isEmpty()}">
+     <td class="pane">${it.widgetEmptyMessage}</td>
+  </j:if>
 </l:pane>
-
 </j:jelly>

--- a/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsWidget/index.jelly
@@ -2,12 +2,17 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <j:if test="${it.showWidget()}">
   <l:pane width="2" title="${it.widgetName}" id="${it.widgetId}">
-    <j:forEach var="w" items="${it.builds}">
-      <tr>
-        <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.name}</a></td>
-        <td class="pane" tooltip="${w.timeToGo}">${w.date}</td>
-      </tr>
-    </j:forEach>
+    <j:if test="${!it.builds.isEmpty()}">
+      <j:forEach var="w" items="${it.builds}">
+        <tr>
+          <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.name}</a></td>
+          <td class="pane" tooltip="${w.timeToGo}">${w.date}</td>
+        </tr>
+      </j:forEach>
+    </j:if>
+    <j:if test="${it.builds.isEmpty()}">
+      <td class="pane">${it.widgetEmptyMessage}</td>
+    </j:if>
   </l:pane>
 </j:if>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/nextexecutions/ParametrizedNextExecutionsWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/ParametrizedNextExecutionsWidget/index.jelly
@@ -1,15 +1,18 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <j:if test="${it.showWidget()}">
-<j:if test="${!it.builds.isEmpty()}">
 <l:pane width="2" title="${it.widgetName}" id="${it.widgetId}">
-  <j:forEach var="w" items="${it.builds}">
-    <tr>
-      <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.shortName}</a></td>
-      <td class="pane" tooltip="${w.timeToGo}">${w.date}</td>
-    </tr>
-  </j:forEach>
+  <j:if test="${!it.builds.isEmpty()}">
+    <j:forEach var="w" items="${it.builds}">
+      <tr>
+        <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.shortName}</a></td>
+        <td class="pane" tooltip="${w.timeToGo}">${w.date}</td>
+      </tr>
+    </j:forEach>
+  </j:if>
+  <j:if test="${it.builds.isEmpty()}">
+     <td class="pane">${it.widgetEmptyMessage}</td>
+  </j:if>
 </l:pane>
-</j:if>
 </j:if>
 </j:jelly>


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/next-executions-plugin/issues/83

### Testing done

- Check that message is displayed on all widget

![Screenshot from 2024-03-09 16-55-25](https://github.com/jenkinsci/next-executions-plugin/assets/825750/b69c675a-d2e6-4789-af56-0e67a0fad550)

- Create one jobs with execution and check that is displayed on different widget

![Screenshot from 2024-03-09 16-45-33](https://github.com/jenkinsci/next-executions-plugin/assets/825750/81dae701-bcbe-407e-aab0-9a97603733b7)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
