### PR TITLE
Implementing a wordwrap so that longer job names will be rendered correct

### DIFF
--- a/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsWidget/index.jelly
+++ b/src/main/resources/hudson/plugins/nextexecutions/NextExecutionsWidget/index.jelly
@@ -5,7 +5,7 @@
     <j:if test="${!it.builds.isEmpty()}">
       <j:forEach var="w" items="${it.builds}">
         <tr>
-          <td class="pane"><a tooltip="${w.name}" href="${w.url}">${w.name}</a></td>
+          <td class="pane" style="word-break:break-all;"><a tooltip="${w.name}" href="${w.url}">${w.name}</a></td>
           <td class="pane" tooltip="${w.timeToGo}">${w.date}</td>
         </tr>
       </j:forEach>


### PR DESCRIPTION
Fixes: #102

When scheduling a job with a long name the word-wrap ensures the schedule time is displayed correctly. The name is continued in the new line like:

![image](https://github.com/jenkinsci/next-executions-plugin/assets/22710627/89bd5d53-96b0-43c6-99f4-540595c6588c)




### Testing done

Tested it with hpi:run

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

